### PR TITLE
pre commit version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt
 
 ENV GOLANG_VERSION 1.16
-ENV PRECOMMIT_VERSION 1.21.0
+ENV PRECOMMIT_VERSION 2.18.1
 
 RUN curl -sSL https://storage.googleapis.com/golang/go$GOLANG_VERSION.linux-amd64.tar.gz \
 		| tar -v -C /usr/local -xz


### PR DESCRIPTION
NodeJS pipeline started failing with errors similar to the one below. These seem to be fixed with the latest version of `pre-commit`.

```bash
$ pre-commit run --all-files
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-eslint.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-eslint:eslint-config-airbnb-base@14.0.0,eslint-config-prettier@6.9.0,eslint-plugin-import@2.18.2,eslint-plugin-prettier@3.1.2,eslint@6.7.2.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-eslint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node', '/root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/npm', 'install')
return code: 1
expected return code: 0
stdout: (none)
stderr:
    /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.27' not found (required by /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node)
    /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.25' not found (required by /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node)
    /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /root/.cache/pre-commit/repo0ixn1b6s/node_env-default/bin/node)
    
Check the log at /root/.cache/pre-commit/pre-commit.log
```